### PR TITLE
Added name attribute

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -1,3 +1,4 @@
+name             "logstash_handler"
 maintainer       "John E. Vincent"
 maintainer_email "lusis.org+github.com@gmail.com"
 license          "Apache 2.0"


### PR DESCRIPTION
Fixes incompatability with ridley gem v3.1.0

Output from ridley
">>>>>> Message: Failed to complete #converge action: [The metadata at
'~/.berkshelf/cookbooks/logstash_handler-0.0.2' does
not contain a 'name' attribute. While Chef does not strictly enforce
this requirement, Ridley cannot continue without a valid metadata 'name'
entry.]"
