### PR TITLE
pin chef_handler version to 1.1.4

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -6,4 +6,4 @@ description      "Installs/Configures a Chef handler for dumping to Logstash ove
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          "0.0.2"
 
-depends "chef_handler"
+depends "chef_handler", "= 1.1.4"


### PR DESCRIPTION
If this is not specified, the handler is broken with the latest version
